### PR TITLE
Issue#13 - Fix Missing glossary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,21 +4,38 @@
 OUTPUT_NAME= Tesi
 LIST_NAME= listOfSections.tex
 PATH_OF_CONTENTS= res/sections
-COMPILER_OPTIONS= pdflatex -interaction=nonstopmode
+MAIN_FILE= main
 
 SHELL := /bin/bash #Need bash not shell
 
 all: compile
 
-compile:
+compile: clean
 	set -e; \
+	function glossary () { \
+	  makeindex -s $(MAIN_FILE).ist -t $(MAIN_FILE).glg -o $(MAIN_FILE).gls \
+	$(MAIN_FILE).glo; \
+	  makeindex -s $(MAIN_FILE).ist -t $(MAIN_FILE).alg -o $(MAIN_FILE).acr \
+	$(MAIN_FILE).acn; \
+  }; \
+	function generatePdf () { \
+	  pdflatex $(MAIN_FILE); \
+	  biber $(MAIN_FILE); \
+	  glossary; \
+  }; \
 	if [[ -a "res/$(LIST_NAME)" ]]; then echo "Removing res/$(LIST_NAME)"; \
 		rm res/$(LIST_NAME); fi; \
 	for i in $(sort $(wildcard $(PATH_OF_CONTENTS)/*.tex)); do \
 		echo "Adding $$i into $(LIST_NAME)"; \
 		echo "\input{$$i}" >> res/$(LIST_NAME); \
 	done; \
-	latexmk -jobname=$(OUTPUT_NAME) -pdflatex='$(COMPILER_OPTIONS)' -pdf main.tex;
+	for j in {1..2}; do \
+	  generatePdf; \
+  done; \
+	for k in {1..2}; do \
+	  pdflatex $(MAIN_FILE); \
+  done; \
+	mv $(MAIN_FILE).pdf $(OUTPUT_NAME).pdf;
 
 clean:
 	git clean -Xfd


### PR DESCRIPTION
Remove `latexmk` for a "manual" compilation. Now it works.

See issue #13
